### PR TITLE
Close log file in child process before exec

### DIFF
--- a/procServ-2.6.0/procServ.cc
+++ b/procServ-2.6.0/procServ.cc
@@ -863,7 +863,10 @@ void openLogFile()
     time_t now;
     struct tm now_tm;
     if (-1 != logFileFD) {
-        close(logFileFD);
+        if (close(logFileFD) != 0) {
+            perror("error closing old log file");
+        }
+        logFileFD = -1;
     }
     time(&now);
     localtime_r(&now, &now_tm);

--- a/procServ-2.6.0/procServ.h
+++ b/procServ-2.6.0/procServ.h
@@ -50,6 +50,7 @@ extern pid_t  procservPid;
 extern rlim_t coreSize;
 extern char   *chDir;
 extern time_t holdoffTime;
+extern int    logFileFD;
 
 #define NL "\r\n"
 

--- a/procServ-2.6.0/processFactory.cc
+++ b/procServ-2.6.0/processFactory.cc
@@ -210,6 +210,10 @@ processClass::processClass(char *exe, char *argv[])
     {
 	    sleep(1);   // to allow AssignProcessToJobObject() to happen - the process we spawn may spawn other processes so we want it to inherit
         setsid();                                  // Become process group leader
+        if (-1 != logFileFD) {
+            close(logFileFD); // so we don't keep log file open after parent daily rotates it
+            logFileFD = -1;
+        }
         if ( setCoreSize ) {                       // Set core size limit?
             getrlimit( RLIMIT_CORE, &corelimit );
             corelimit.rlim_cur = coreSize;


### PR DESCRIPTION
The child process was inheriting the log file handle and thus keeping it open after the parent rotated files. Should be resolved by closing handle after fork() and before exec().

See ISISComputingGroup/IBEX#8555
