### PR TITLE
Use timers instead of threads for log rotation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
   
   post {
     always {
-      archiveArtifacts artifacts: '**/config.log', caseSensitive: false
+      archiveArtifacts artifacts: '**/config.log, cyg_copy.log, minicgy_copy.log', caseSensitive: false
       logParser ([
             projectRulePath: 'parse_rules',
             parsingRulesPath: '',

--- a/build.bat
+++ b/build.bat
@@ -2,7 +2,8 @@ setlocal
 REM this is a minimal cygwin install used at ibex runtime
 REM we install procServ and conserver into this directory
 robocopy "c:\mini_cygwin64" "%~dp0cygwin" /E /PURGE /NFL /NDL /NP ^
-    /XF "rebase.db.x86_64" /XD "c:\mini_cygwin64\home\gamekeeper" /R:5
+    /XF "rebase.db.x86_64" /XD "c:\mini_cygwin64\home\gamekeeper" /R:5 ^
+    /log:"%~dp0minicyg_copy.log"
 if %ERRORLEVEL% GEQ 4 exit /b %ERRORLEVEL%
 REM disable ASLR in copied cygwin DLL to avoid later fork issues
 call %~dp0disable_aslr.bat %~dp0cygwin

--- a/conserver-src/compat.h
+++ b/conserver-src/compat.h
@@ -1,7 +1,6 @@
 #include <config.h>
 
 /* things everything seems to need */
-#include <pthread.h>
 #include <stdio.h>
 #include <sys/param.h>
 #include <sys/socket.h>

--- a/conserver-src/configure.ac
+++ b/conserver-src/configure.ac
@@ -38,7 +38,7 @@ AC_DEFINE_UNQUOTED(CONFIGINVOCATION, "$0 $*")
 
 dnl ### Set some option defaults. ###################################
 if test -z "$CFLAGS"; then
-  CFLAGS="-O"
+  CFLAGS="-Wall -g"
 fi
 MKDIR="mkdir -p -m 755"
 AC_SUBST(MKDIR)
@@ -359,11 +359,12 @@ AC_TRY_COMPILE([#include <sys/types.h>
 dnl ### Host specific checks. ######################################
 AC_CANONICAL_HOST
 
-## no longer works on cygwin if we want ssl
-#if test "$host_os" = "cygwin"; then
+if test "$host_os" = "cygwin"; then
+    LDFLAGS="$LDFLAGS -g"
+## static no longer works on cygwin if we want ssl
+#    AC_MSG_RESULT("Enabling static linking")
 #    LDFLAGS="$LDFLAGS -static"
-#	AC_MSG_RESULT("Enabling static linking")
-#fi
+fi
 
 case "$host" in
 *-*-hpux*)
@@ -839,7 +840,6 @@ AC_ARG_WITH(ipv6,
 		AC_MSG_RESULT(no)
 		;;
 	esac],[AC_MSG_RESULT(no)])
-
 
 dnl Checks for pty allocation...
 dnl According to the xemacs distribution:

--- a/conserver-src/conserver/main.c
+++ b/conserver-src/conserver/main.c
@@ -1215,45 +1215,40 @@ VerifyEmptyDirectory(char *d)
 #endif
 
 /*
- * force a daily log rotation by raising SIGUSR2 when date changes
+ * force a daily log rotation by raising SIGUSR2 every day
  */
-static void*
-logRotator(void* arg)
+static void
+setupLogRotator()
 {
-    pthread_t main_thread = *(pthread_t*)arg;
-    time_t now = time(NULL);
+    timer_t timerid;
+    struct sigevent sev;
+    struct itimerspec its;
+    time_t now;
     struct tm now_tm;
-    int day, old_day;
-    struct timespec delay;
-    delay.tv_sec = 60;
-    delay.tv_nsec = 0;
+    const int SECONDS_IN_DAY = 24 * 3600;
+    int secs_to_midnight;
+    memset(&sev, 0, sizeof(struct sigevent));
+    sev.sigev_notify = SIGEV_SIGNAL;
+    sev.sigev_signo = SIGUSR2;
+    if (timer_create(CLOCK_REALTIME, &sev, &timerid) == -1) {
+        Error("timer_create(): %s", strerror(errno));
+        return;
+    }
+    time(&now);
     localtime_r(&now, &now_tm);
-    old_day = now_tm.tm_mday;
-    sigset_t set;
-    sigemptyset(&set);
-    /* ignore SIGUSR1 and SIGUSR1 used to signal process actions */
-    sigaddset(&set, SIGUSR1);
-    sigaddset(&set, SIGUSR2);
-    if (pthread_sigmask(SIG_BLOCK, &set, NULL) < 0) {
-        Msg("logRotator: error setting signal mask");
+    /* not sure if we need to worry about being started at exactly midnight?
+     * also add a few seconds to leaps seconds or other stuff
+     */
+    secs_to_midnight = 10 + SECONDS_IN_DAY - now_tm.tm_sec - 60 * now_tm.tm_min - 3600 * now_tm.tm_hour;
+    its.it_value.tv_sec = secs_to_midnight; // Initial expiration
+    its.it_value.tv_nsec = 0;
+    its.it_interval.tv_sec = SECONDS_IN_DAY; // Expire interval
+    its.it_interval.tv_nsec = 0;
+    if (timer_settime(timerid, 0, &its, NULL) == -1) {
+        Error("timer_settime(): %s", strerror(errno));
+        return;
     }
-    while(1) {
-        time(&now);
-        localtime_r(&now, &now_tm);
-        day = now_tm.tm_mday;
-        if (day != old_day) {
-            if (pthread_kill(main_thread, SIGUSR2) < 0) {
-                Msg("logRotator: error rotating logs day %d", day);
-            } else {
-                Msg("logRotator: rotating logs day %d", day);
-            }
-            old_day = day;
-        }
-        if (nanosleep(&delay, NULL) < 0) {
-            Msg("logRotator: nanosleep interrupted day %d", day);
-        }
-    }
-    return NULL;
+    Msg("Setup log rotator to signal in %d seconds and repeat daily", secs_to_midnight);
 }
 
 /* find out where/who we are						(ksb)
@@ -1268,8 +1263,6 @@ int
 main(int argc, char **argv)
 {
     int i;
-    pthread_t log_rotator_thread;
-    pthread_t main_thread;
     FILE *fpConfig = (FILE *)0;
     static char acOpts[] = "7a:b:c:C:dDEFhiL:m:M:noO:p:P:RSuU:Vv";
 #ifndef __CYGWIN__
@@ -1546,6 +1539,7 @@ main(int argc, char **argv)
 	    bindPort = ntohs((unsigned short)pSE->s_port);
 	}
     }
+    Msg("bind port %hu", bindPort);
 # endif
 
     /* set up the secondary port to bind to */
@@ -1615,6 +1609,7 @@ main(int argc, char **argv)
 	(interface[0] == '*' && interface[1] == '\000'))
 	bindAddr = INADDR_ANY;
     else {
+    Msg("interface specified with -M as %s", interface);
 # if HAVE_INET_ATON
 	if (inet_aton(interface, &inetaddr) == 0) {
 	    Error("inet_aton(%s): %s", interface, "invalid IP address");
@@ -1629,10 +1624,13 @@ main(int argc, char **argv)
 	}
 # endif
     }
-    if (fDebug) {
-	struct in_addr ba;
-	ba.s_addr = bindAddr;
-	CONDDEBUG((1, "main(): bind address set to `%s'", inet_ntoa(ba)));
+    {
+	    struct in_addr ba;
+	    ba.s_addr = bindAddr;
+        if (fDebug) {
+	        CONDDEBUG((1, "main(): bind address set to `%s'", inet_ntoa(ba)));
+        }
+        Msg("bind address set to `%s'", inet_ntoa(ba));
     }
 #endif
 
@@ -1848,15 +1846,11 @@ main(int argc, char **argv)
 
 	fflush(stdout);
 	fflush(stderr);
-    main_thread = pthread_self();
-    if (pthread_create(&log_rotator_thread, NULL, logRotator, &main_thread) != 0) {
-        Msg("Master(): unable to create log rotator thread");
-    }
+    setupLogRotator();
 	Master();
 
 	/* stop putting kids back, and shoot them
 	 */
-    pthread_cancel(log_rotator_thread);
 	SimpleSignal(SIGCHLD, SIG_DFL);
 	SignalKids(SIGTERM);
     }

--- a/conserver-src/conserver/master.c
+++ b/conserver-src/conserver/master.c
@@ -680,7 +680,7 @@ void
 Master(void)
 {
     int cfd;
-    int msfd;
+    int msfd = -1;
     socklen_t so;
     fd_set rmask, wmask;
 #if USE_IPV6 || !USE_UNIX_DOMAIN_SOCKETS
@@ -762,6 +762,7 @@ Master(void)
 
       fail:
 	close(msfd);
+    msfd = -1;
     }
 
     if (listen(msfd, SOMAXCONN) < 0) {
@@ -843,6 +844,7 @@ Master(void)
 	      strerror(errno));
 	return;
     }
+    Msg("listening on port %hu", ntohs(master_port.sin_port));
 #endif
 
     fp = fopen(PIDFILE, "w");

--- a/jenkins_build.bat
+++ b/jenkins_build.bat
@@ -1,8 +1,11 @@
 setlocal
-call build.bat
-if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+call %~dp0start_cygserver.bat c:\cygwin64
+call %~dp0build.bat
+set errcode=%ERRORLEVEL%
+call %~dp0stop_cygserver.bat c:\cygwin64
+if %errcode% NEQ 0 exit /b %errcode%
 set "CYGCOPYDIR=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Binaries\EPICS_Tools\cygwin"
-robocopy "%~dp0cygwin" "%CYGCOPYDIR%" /E /PURGE /NFL /NDL /NP /XF "rebase.db.x86_64" /R:5
+robocopy "%~dp0cygwin" "%CYGCOPYDIR%" /E /PURGE /NFL /NDL /NP /XF "rebase.db.x86_64" /R:5 /log:"%~dp0cyg_copy.log"
 if %ERRORLEVEL% GEQ 4 exit /b %ERRORLEVEL%
 c:\cygwin64\bin\peflags.exe --dynamicbase=0 "%CYGCOPYDIR%\bin\cygwin1.dll"
 exit /b 0

--- a/start_cygserver.bat
+++ b/start_cygserver.bat
@@ -1,17 +1,24 @@
 @echo off
 setlocal
-@echo %DATE% %TIME% starting cygserver
-set "PATH=%~dp0cygwin\bin;%PATH%"
+if "%1" == "" (
+    set "MYCYGHOME=%~dp0cygwin"
+) else (
+    set "MYCYGHOME=%1"
+)
+@echo %DATE% %TIME% starting cygserver from %MYCYGHOME%
+set "PATH=%MYCYGHOME%\bin;%PATH%"
 for /f %%i in ( 'tasklist /fi  "IMAGENAME eq cygserver.exe"' ) do set PROC=%%i
 if "%PROC%" == "cygserver.exe" (
     @echo %DATE% %TIME% cygserver is already running
     exit /b 0
 )
-if not exist "%~dp0cygwin\etc\cygserver.conf" (
-    copy %~dp0cygwin\etc\defaults\etc\cygserver.conf %~dp0cygwin\etc\cygserver.conf
+if not exist "%MYCYGHOME%\etc\cygserver.conf" (
+    copy %MYCYGHOME%\etc\defaults\etc\cygserver.conf %MYCYGHOME%\etc\cygserver.conf
 )
-powershell -Command "Start-Process cmd -Args /c,\"%~dp0cygwin\usr\sbin\cygserver.exe --stderr --no-syslog\" -RSE C:\Instrument\Var\logs\ibex_server\cygserver_err.log -RSO C:\Instrument\Var\logs\ibex_server\cygserver_out.log -WindowStyle Hidden"
+if not exist "C:\Instrument\Var\logs\ibex_server" mkdir C:\Instrument\Var\logs\ibex_server
+powershell -Command "Start-Process cmd -Args /c,\"%MYCYGHOME%\usr\sbin\cygserver.exe --stderr --no-syslog\" -RSE C:\Instrument\Var\logs\ibex_server\cygserver_err.log -RSO C:\Instrument\Var\logs\ibex_server\cygserver_out.log -WindowStyle Hidden"
 REM we started using cygserver due to a site ldap issue - seems to need at least 45 seconds
 REM to do and cache this lookup
 @echo %DATE% %TIME% waiting 60 seconds for cygserver to complete setup
 waitfor /t 60 WillNeverHappen >NUL 2>&1
+tasklist /fi  "IMAGENAME eq cygserver.exe"

--- a/stop_cygserver.bat
+++ b/stop_cygserver.bat
@@ -1,11 +1,16 @@
 @echo off
 setlocal
-@echo %DATE% %TIME% stopping cygserver
-set "PATH=%~dp0cygwin\bin;%PATH%"
+if "%1" == "" (
+    set "MYCYGHOME=%~dp0cygwin"
+) else (
+    set "MYCYGHOME=%1"
+)
+@echo %DATE% %TIME% stopping cygserver from %MYCYGHOME%
+set "PATH=%MYCYGHOME%\bin;%PATH%"
 for /f %%i in ( 'tasklist /fi  "IMAGENAME eq cygserver.exe"' ) do set PROC=%%i
 if "%PROC%" == "cygserver.exe" (
     REM only do this if cygserver is running as it can take a while if there are site ldap issues
-    %~dp0cygwin\usr\sbin\cygserver.exe --shutdown 
+    %MYCYGHOME%\usr\sbin\cygserver.exe --shutdown
     REM wait a bit and kill if shutdown not complete
     ping -n 5 127.0.0.1 >NUL
     taskkill /f /im cygserver.exe 2>NUL


### PR DESCRIPTION
Use timer rather than threads - `pthread_create` started to crash on usage, this stops conserver working properly and so you are unable to connect via `console` command to IOCs